### PR TITLE
Feat: Add 'Shutdown Server' button to web UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Python virtual environment
+venv/
+**/venv/
+
+# Python cache files
+__pycache__/
+**/*__pycache__*/
+*.pyc
+*.pyo
+*.pyd
+
+# IDE and editor specific files
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS specific files
+.DS_Store
+Thumbs.db

--- a/README.md
+++ b/README.md
@@ -63,21 +63,48 @@ This project is a simple nutrition tracker with a command-line interface (CLI) a
     pip install -r requirements.txt
     ```
 
-### Running the Web Interface (for adding ingredients)
+### Simplified Launch (Recommended)
 
-1.  **Ensure your virtual environment is activated.**
+After completing the installation steps (including creating the virtual environment and installing dependencies), you can use the provided launch scripts for a one-click experience:
+
+*   **On Windows:**
+    1.  Navigate to the project directory in File Explorer.
+    2.  Double-click `start_app.bat`.
+*   **On macOS and Linux:**
+    1.  Open your terminal and navigate to the project directory.
+    2.  Make the script executable (only needs to be done once):
+        ```bash
+        chmod +x start_app.sh
+        ```
+    3.  Run the script:
+        ```bash
+        ./start_app.sh
+        ```
+
+These scripts will:
+1.  Activate the virtual environment.
+2.  Start the Flask web server (for adding ingredients) in the background. You can access it at `http://127.0.0.1:5000/` (or specifically the `/add_ingredient` page). The web interface includes a "Shutdown Server" button which will stop the web server.
+3.  Start the main CLI application in the current terminal window.
+4.  When you exit the CLI (e.g., by using the 'exit' option in the CLI or pressing Ctrl+C), the script will attempt to stop the Flask server (if it's still running) and deactivate the virtual environment. If you've used the "Shutdown Server" button in the web UI, the Flask server will already be stopped.
+
+### Manual Launch (Alternative)
+
+If you prefer to run the components separately:
+
+#### Running the Web Interface (for adding ingredients)
+
+1.  **Ensure your virtual environment is activated (see Installation).**
 2.  **Run the Flask application:**
     ```bash
     python app.py
     ```
 3.  Open your web browser and go to: `http://127.0.0.1:5000/`
+    You can fill in the form to add new ingredients to the `ingredient_database.json` file.
 
-    You should see the "Add New Ingredient" page. You can fill in the form to add new ingredients to the `ingredient_database.json` file.
+#### Running the Command-Line Interface (CLI)
 
-### Running the Command-Line Interface (CLI)
-
-1.  **Ensure your virtual environment is activated.**
-2.  **Run the CLI application:**
+1.  **Ensure your virtual environment is activated (see Installation).**
+2.  **Run the CLI application (in a separate terminal if the web interface is running):**
     ```bash
     python main_cli.py
     ```

--- a/app.py
+++ b/app.py
@@ -21,6 +21,24 @@ def add_ingredient_page():
     # Serves the add_ingredient.html page
     return render_template('add_ingredient.html')
 
+@app.route('/shutdown-server', methods=['GET'])
+def shutdown_server():
+    shutdown_func = request.environ.get('werkzeug.server.shutdown')
+    if shutdown_func is None:
+        # This might happen if not running with Werkzeug's dev server
+        # (e.g., when deployed with Gunicorn, uWSGI)
+        # For simplicity in a dev environment, we'll assume Werkzeug.
+        app.logger.warning("Shutdown function not found in request environment. Server may not shut down.")
+        return "Error: Could not shut down server. Shutdown function not available. Please close the terminal/script manually.", 500
+
+    try:
+        app.logger.info("Server shutdown requested via /shutdown-server endpoint.")
+        shutdown_func()
+        return "Server is shutting down... You can close this page. Please also close the CLI window if it's still open."
+    except Exception as e:
+        app.logger.error(f"Error during server shutdown: {e}")
+        return f"Error during server shutdown: {e}. Please close the terminal/script manually.", 500
+
 @app.route('/track_meal')
 def track_meal_page():
     # Serves the track_meal.html page

--- a/start_app.bat
+++ b/start_app.bat
@@ -1,0 +1,37 @@
+@echo off
+
+REM Get the directory where the script is located
+set "SCRIPT_DIR=%~dp0"
+
+REM Activate virtual environment
+if exist "%SCRIPT_DIR%venv\Scripts\activate.bat" (
+    echo Activating virtual environment...
+    call "%SCRIPT_DIR%venv\Scripts\activate.bat"
+) else (
+    echo Virtual environment 'venv' not found. Please run setup first.
+    exit /b 1
+)
+
+echo Starting Flask web server (for adding ingredients)...
+REM Start Flask app in a new window minimized, as true backgrounding is tricky
+start "Flask Server" /MIN python "%SCRIPT_DIR%app.py"
+echo Flask app running. Access it at http://127.0.0.1:5000/
+echo Note: The Flask server window will be minimized. Close it manually when done, or it will close when this main script window is closed.
+
+echo Starting CLI application...
+python "%SCRIPT_DIR%main_cli.py"
+
+echo.
+echo CLI application has finished.
+echo Closing Flask server (if it was started by this script and is still running)...
+REM Attempt to close the Flask server by title. This may not always work reliably.
+taskkill /FI "WINDOWTITLE eq Flask Server*" /IM python.exe /F >nul 2>&1
+
+REM Deactivate virtual environment
+if defined VIRTUAL_ENV (
+    echo Deactivating virtual environment...
+    call "%SCRIPT_DIR%venv\Scripts\deactivate.bat"
+)
+
+echo Exiting.
+pause

--- a/start_app.sh
+++ b/start_app.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Get the directory where the script is located
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+# Activate virtual environment
+if [ -d "$SCRIPT_DIR/venv" ]; then
+    echo "Activating virtual environment..."
+    source "$SCRIPT_DIR/venv/bin/activate"
+else
+    echo "Virtual environment 'venv' not found. Please run setup first."
+    exit 1
+fi
+
+# Start Flask app in the background
+echo "Starting Flask web server (for adding ingredients)..."
+python "$SCRIPT_DIR/app.py" &
+FLASK_PID=$!
+echo "Flask app running with PID $FLASK_PID. Access it at http://127.0.0.1:5000/"
+
+# Function to clean up background process on exit
+cleanup() {
+    echo "Stopping Flask web server (PID $FLASK_PID)..."
+    kill $FLASK_PID
+    # Deactivate virtual environment if it was activated by this script
+    if type deactivate > /dev/null 2>&1; then
+        echo "Deactivating virtual environment..."
+        deactivate
+    fi
+    echo "Exiting."
+    exit 0
+}
+
+# Trap SIGINT (Ctrl+C) and SIGTERM to run cleanup
+trap cleanup SIGINT SIGTERM
+
+# Start CLI app in the foreground
+echo "Starting CLI application..."
+python "$SCRIPT_DIR/main_cli.py"
+
+# Cleanup after CLI finishes (if not interrupted by Ctrl+C)
+cleanup

--- a/templates/add_ingredient.html
+++ b/templates/add_ingredient.html
@@ -49,9 +49,43 @@
             <button type="submit">Save Ingredient</button>
         </form>
         <div id="statusMessage" class="status-message"></div>
+
+        <div class="shutdown-container" style="margin-top: 20px; padding-top: 20px; border-top: 1px solid #ccc;">
+            <p>If you are running this application using the launch script, you can shut down the web server here.</p>
+            <button id="shutdownServerBtn">Shutdown Server</button>
+            <div id="shutdownMessage" class="status-message" style="margin-top: 10px;"></div>
+        </div>
     </div>
 
     <script>
+        // Shutdown server button event listener
+        const shutdownBtn = document.getElementById('shutdownServerBtn');
+        if (shutdownBtn) {
+            shutdownBtn.addEventListener('click', async function() {
+                const shutdownMessageEl = document.getElementById('shutdownMessage');
+                shutdownMessageEl.textContent = 'Attempting to shut down server...';
+                shutdownMessageEl.className = 'status-message info';
+                try {
+                    const response = await fetch('/shutdown-server');
+                    const result = await response.text(); // Get text response
+                    shutdownMessageEl.textContent = result;
+                    if (response.ok) {
+                        shutdownMessageEl.classList.add('success');
+                        // Optionally disable the button
+                        shutdownBtn.disabled = true;
+                        // Try to close the window, may not work depending on browser settings
+                        // setTimeout(() => window.close(), 3000);
+                    } else {
+                        shutdownMessageEl.classList.add('error');
+                    }
+                } catch (error) {
+                    console.error('Error shutting down server:', error);
+                    shutdownMessageEl.textContent = 'Failed to send shutdown command. The server might already be down or unreachable.';
+                    shutdownMessageEl.classList.add('error');
+                }
+            });
+        }
+
         document.getElementById('addIngredientForm').addEventListener('submit', async function(event) {
             event.preventDefault(); // Prevent default form submission
 


### PR DESCRIPTION
- Modified `templates/add_ingredient.html` to include a 'Shutdown Server' button.
- Added JavaScript to this button to call a new `/shutdown-server` Flask endpoint.
- Modified `app.py` to add the `/shutdown-server` route, which attempts to gracefully shut down the Werkzeug development server.
- Updated `README.md` to reflect the new shutdown functionality in the web UI.